### PR TITLE
ignore erblint failure

### DIFF
--- a/src/erbLint.ts
+++ b/src/erbLint.ts
@@ -95,8 +95,8 @@ export class ERBLint {
     const task = new Task(uri, token => {
       const process = this.executeERBLint(args, {cwd: currentPath}, (error, stdout, stderr) => {
         if (token.isCanceled) return
+        if (this.reportError(error, stderr)) return
 
-        this.reportError(error, stderr)
         onDidExec && onDidExec(stdout)
         token.finished()
         onComplete && onComplete()
@@ -154,7 +154,9 @@ export class ERBLint {
   private reportError(error: cp.ExecException | null, stderr: string): boolean {
     const errorOutput = stderr.toString()
 
-    if (error && error.code === 127) {
+    if (/^no files found/.test(errorOutput)) {
+      return true
+    } else if (error && error.code === 127) {
       vscode.window.showWarningMessage(stderr)
       return true
     } else if (errorOutput.length > 0 && !this.config.suppressERBLintWarnings) {


### PR DESCRIPTION
Thanks for making this useful extension. ✨ 

I sometimes write json and xml in erb.
In that case I put the following in my .erb-lint.yml
```bash
$ cat .erb-lint.yml
exclude:
  - 'json.erb'
```

When I edit json.erb, erb-lint says "no files found...".
As a result vscode-erb-linter gives the following warning
> command bundle exec erblint returns empty output! please check configuration.

My hope is that the exlude file does not give the warning.
This PR is for that purpose.

I think it is okay to ignore this erb-lint failure.
https://github.com/Shopify/erb-lint/search?q=failure
```ruby
      if !@files.empty? && lint_files.empty?
        failure!("no files found...\n")
      elsif lint_files.empty?
        failure!("no files found or given, specify files or config...\n#{option_parser}")
```



